### PR TITLE
fix(sequelize): fix duplicated unique indexes

### DIFF
--- a/packages/sequelize/src/models.ts
+++ b/packages/sequelize/src/models.ts
@@ -26,7 +26,7 @@ export const User = {
     primaryKey: true,
   },
   name: { type: DataTypes.STRING },
-  email: { type: DataTypes.STRING, unique: true },
+  email: { type: DataTypes.STRING, unique: 'email' },
   emailVerified: { type: DataTypes.DATE },
   image: { type: DataTypes.STRING },
 }
@@ -38,7 +38,7 @@ export const Session = {
     primaryKey: true,
   },
   expires: { type: DataTypes.DATE, allowNull: false },
-  sessionToken: { type: DataTypes.STRING, unique: true, allowNull: false },
+  sessionToken: { type: DataTypes.STRING, unique: 'sessionToken', allowNull: false },
   userId: { type: DataTypes.UUID },
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## Reasoning 💡

<!--
What changes are being made? What feature/bug is being fixed here?

IMPORTANT: Which, if any, adapter is being affected? Or are you wanting to add
a new one?
 -->
When using the sequelize adapter and running sequelize sync, the unique indexes are duplicated on each run because
they weren't declared correctly. After some time, this error is thrown: `SequelizeDatabaseError: Too many keys specified; max 64 keys allowed`. The fix applied is coming from this suggestion: https://github.com/sequelize/sequelize/issues/9653#issuecomment-660269195

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

~[] Documentation~
- [ ] Tests
- [ ] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟
None
<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
